### PR TITLE
Show the "Latest Post" section only if posts are available

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,6 +7,7 @@
     <div class="content">
       {{ partial "header.html" . }}
       {{ .Content }}
+      {{ if gt (len ( where .Site.RegularPages "Section" "posts" )) 0 }}
       <h1>Latest Post</h1>
       <section>
         {{ range (first 3 (where .Site.RegularPages "Section" "posts" ).ByDate.Reverse) }}
@@ -16,6 +17,7 @@
           <p>
         {{ end }}
       </section>
+      {{ end }}
     </div>
   </main>
 </body>


### PR DESCRIPTION
I feel that the "Latest Post" Section on the landing page should exist only if the user has a post documented. The check added in this patch just does that.