### PR TITLE
Add empty scss/_extra.scss file to allow external SCSS customization

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,8 @@
     <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ .Site.BaseURL }}/feed.json" />
     <link rel="shortcut icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=">
     {{ $styles := resources.Get "scss/styles.scss" | toCSS (dict "outputStyle" "compressed") | minify }}
-    <style>{{ $styles.Content | safeCSS }}</style>
+    {{ $styles_extra := resources.Get "scss/_extra.scss" | toCSS (dict "outputStyle" "compressed") | minify }}
+    <style>{{ $styles.Content | safeCSS }} {{ $styles_extra.Content | safeCSS }}</style>
   
     {{ if .IsHome -}}
   <script type="application/ld+json">


### PR DESCRIPTION
This allows customization of the SCSS outside of the theme by overriding the empty *scss/_extra.scss" in * assets/scss/_extra.scss* of the blog.