### PR TITLE
switch analytics partial to support GA4

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{{ if ne .Description "" }}{{ .Description }}{{ else }}{{ .Site.Params.description }}{{ end }}">
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/schema.html" . }}
-    {{ template "_internal/google_analytics_async.html" . }}
+    {{ template "_internal/google_analytics.html" . }}
     <link rel="canonical" href="{{ .Permalink }}">
     <link rel="icon" href="{{ .Site.BaseURL }}/assets/favicon.ico">
     <link rel="dns-prefetch" href="https://www.google-analytics.com">


### PR DESCRIPTION
Google is phasing out Universal Analytics, so per the hugo docs use the non-async analytics template.