### PR TITLE
Function {{ now.Format "2022"}} wrong

### DIFF
--- a/layouts/index.xml
+++ b/layouts/index.xml
@@ -6,7 +6,7 @@
     <link>{{ .Site.BaseURL }}</link>
     <!-- Optional channel elements -->
     <language>en</language>
-    <copyright>Copyright {{ now.Format "2022"}}, Calvin Tran</copyright>
+    <copyright>Copyright {{ now.Format "2006"}}, Calvin Tran</copyright>
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     <generator>Hugo - gohugo.io</generator>
     <docs>http://cyber.harvard.edu/rss/rss.html</docs>


### PR DESCRIPTION
Hugo returns 101010, instead of the current year, because of the wrong year number. With 2006 it returns the current year.
https://gohugo.io/functions/now/