### PR TITLE
Fix home to baseURL

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <header>
 <p style="padding: 0;margin: 0;">
-  <a href="/">
+  <a href="{{ .Site.BaseURL }}">
     <b>{{ .Site.Title }}</b>
     <span class="text-stone-500 animate-blink">▮</span>
   </a>


### PR DESCRIPTION
If you hosted your blog in a subpath (https://example.com/blog) I think you want that the header link redirects you to your blog home, not to your domain root.