### PR TITLE
Added force-wrapping for the code

### DIFF
--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -92,6 +92,8 @@ code, pre {
 code {
     margin: .1rem;
     border: none;
+    overflow: visible;
+    overflow-wrap: anywhere;
 }
 
 ul {


### PR DESCRIPTION
Hello. Thanks for making this cool theme. 

I'd like to suggest a change to the behavior of code text-wrapping in this pull request. 

It's relatively common for people to put something that's very long like 'access token' or 'dummy API key' in \<code\>

In fact, this breaks how things look on mobile screen and mess up with the horizontal scroll, which is not elegant. (I can follow up with a pic/screenshot if you want to take a look.)

And if the lines really matter, people usually opt for the ```code block``` instead of `<code>`

You can reject this request if it doesn't align with your way. I don't mind that at all!
